### PR TITLE
Remove unnecessary NuGet package

### DIFF
--- a/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore.DesignTools/CustomControlLibrary.WpfCore.DesignTools.csproj
+++ b/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore.DesignTools/CustomControlLibrary.WpfCore.DesignTools.csproj
@@ -74,9 +74,6 @@
     <Compile Include="VSThemeAPIDemoAdornerProvider.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <Page Include="ColorsListControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore.DesignTools/packages.config
+++ b/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore.DesignTools/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.VisualStudio.DesignTools" version="16.3.29004.11111" targetFramework="net472" />
-</packages>


### PR DESCRIPTION
The WPF sample includes a reference to a NuGet package that is not publicly available. (Microsoft.VisualStudio.DesignTools version=16.3.29004.11111)

Presumably this was a private assembly used while the functionality was being developed within Microsoft.
This functionality is now available within the assemblies that ship within Visual Studio and so this package reference is no longer needed.

X-Ref #2 - which complains that this NuGet package is publicly isn't available.